### PR TITLE
Development proxy

### DIFF
--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -18,7 +18,7 @@ module.exports = function() {
     // --> boot files are part of "main.js"
     // https://quasar.dev/quasar-cli/boot-files
     boot: ["i18n", "axios"],
-    target : 'node',
+    target: "node",
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-css
     css: ["app.scss"],
@@ -68,14 +68,14 @@ module.exports = function() {
       open: true, // opens browser window automatically
       proxy: {
         // proxy all requests starting with /api to GeriLife server
-        '/api': {
-          target: 'http://localhost:3000',
+        "/api": {
+          target: "http://localhost:3000",
           changeOrigin: true,
           pathRewrite: {
-            '^/api': '',
-          },
-        },
-      },
+            "^/api": ""
+          }
+        }
+      }
     },
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -67,7 +67,7 @@ module.exports = function() {
       port: 8080,
       open: true, // opens browser window automatically
       proxy: {
-        // proxy all requests starting with /api to jsonplaceholder
+        // proxy all requests starting with /api to GeriLife server
         '/api': {
           target: 'http://localhost:3000',
           changeOrigin: true,

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -65,7 +65,17 @@ module.exports = function() {
     devServer: {
       https: false,
       port: 8080,
-      open: true // opens browser window automatically
+      open: true, // opens browser window automatically
+      proxy: {
+        // proxy all requests starting with /api to jsonplaceholder
+        '/api': {
+          target: 'http://localhost:3000',
+          changeOrigin: true,
+          pathRewrite: {
+            '^/api': '',
+          },
+        },
+      },
     },
 
     // https://quasar.dev/quasar-cli/quasar-conf-js#Property%3A-framework


### PR DESCRIPTION
Add a proxy configuration, so the development environment matches deployment. This configuration will proxy any requests starting with `/api` to the GeriLife server running at port 3000 (Meteor default port), so we can hopefully do without any Docker configuration to run our client/server on the same development computer.

https://quasar.dev/quasar-cli/api-proxying