### PR TITLE
34 avoiding reload in submit button

### DIFF
--- a/src/features/homes/add-group.vue
+++ b/src/features/homes/add-group.vue
@@ -59,8 +59,11 @@ export default {
   methods: {
     maxLength,
     requiredValidation,
-    async onSubmit() {
+    async onSubmit($ev) {
       const result = await this.$refs.manageGroup.validate();
+      if ($ev) {
+        $ev.preventDefault();
+      }
       if (!result) return;
       const apiResponse = await addOrUpdateAGroup({
         _id: this.group ? this.group._id : null,

--- a/src/features/homes/add-home.vue
+++ b/src/features/homes/add-home.vue
@@ -81,8 +81,11 @@ export default {
 
   methods: {
     requiredValidation,
-    async onSubmit() {
+    async onSubmit($ev) {
       const result = await this.$refs.manageHome.validate();
+      if ($ev) {
+        $ev.preventDefault();
+      }
       if (!result) return;
       const apiResponse = await addOrUpdateHome({
         _id: this.home ? this.home._id : undefined,
@@ -92,6 +95,7 @@ export default {
       if (apiResponse) {
         this.$emit("close", true);
       }
+      
     },
   },
 };

--- a/src/features/homes/assign-manager.vue
+++ b/src/features/homes/assign-manager.vue
@@ -163,6 +163,9 @@ export default {
 
     async onSubmit($ev) {
       const result = await this.$refs.assignManager.validate();
+      if ($ev) {
+        $ev.preventDefault();
+      }
       if (!result) return;
       const apiResponse = await assignManager({
         groupId: this.groupId,

--- a/src/features/login/index.vue
+++ b/src/features/login/index.vue
@@ -47,7 +47,6 @@
       <q-card-section class="row">
         <q-space />
         <q-form class="col-8" ref="forgotPwdForm">
-
           <q-input
             v-model="toEmail"
             :rules="[(v) => requiredValidation(v), (v) => validateEmail(v)]"
@@ -93,8 +92,11 @@ export default {
     };
   },
   methods: {
-    async login() {
-      console.log("login form submitted")
+    async login(event) {
+      if (event) {
+        event.preventDefault();
+      }
+      console.log("login form submitted");
       const result = await this.$refs.loginForm.validate();
 
       if (!result) {


### PR DESCRIPTION
closes #34 


This should avoid the page reload on login failure.
Adding prevent default at places we use q-form submit