### PR TITLE
34 adding api prefix for axios checks

### DIFF
--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -8,7 +8,7 @@ const axiosInstance = axios.create();
 export default () => {
   axiosInstance.interceptors.request.use(
     async config => {
-      if (config.url !== "/users/login") {
+      if (config.url.indexOf("/users/login") === -1) {
         const token = getCookie("token");
         if (token) {
           config.headers["Authorization"] = "Bearer " + token;
@@ -20,9 +20,8 @@ export default () => {
       config.params["_t"] = new Date().getTime();
 
       if (
-        config.url === "/users/login" ||
-        config.url === "/methods/sendResetEmail" ||
-        config.url.startsWith("/resident/")
+        config.url.indexOf("/users/login") > -1 ||
+        config.url.indexOf("/methods/sendResetEmail") > -1
       ) {
         return config;
       }

--- a/src/services/login.js
+++ b/src/services/login.js
@@ -14,7 +14,6 @@ export const loginToServer = async (email, password) => {
 
     console.log(cookieData);
     document.cookie = `token=${cookieData.token}; expires=${cookieData.tokenExpires}`;
-    
     return true;
   } catch (error) {
     errorNotifier(error);
@@ -35,7 +34,7 @@ export const logout = async () => {
   return false;
 };
 
-export const sendResetEmail = async (email) => {
+export const sendResetEmail = async email => {
   try {
     const { data: result } = await $axios.post("/api/methods/sendResetEmail", {
       toEmail: email


### PR DESCRIPTION
@brylie  Turns out the issue was due to the check inside axios file. We had compared exact URLs there for redirection, but since we added the `API` prefix in the URLs the checks were failing and the UI kept reloading after every login check