### PR TITLE
Using vue router reload instead on js window reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Client-only code for Wellbeing project.
 After cloning the app,
 - Run `Yarn` command to installed dependencies
 - To start the application in development mode run `yarn dev` which will start the Application on the port 8080.
-- The meteor server supports HTTP requests. The method and collection methods are available by the routes `/methods/<method-name>` and `/collections/<collection-name>`. So to work with the meteor server, the frontend must know where to redirect the requests to. So to run the App successfully, the meteor server must be on. Set the URL of the server in the  `.env` file of the frontend folder using the key `BASE_URL`. E.g. in local mode `BASE_URL=http://localhost:3000/`
+- The meteor server supports HTTP requests. The method and collection methods are available by the routes `/api/methods/<method-name>` and `/collections/<collection-name>`. So to work with the meteor server, the frontend must know where to redirect the requests to. So to run the App successfully, the meteor server must be on. Set the URL of the server in the  `.env` file of the frontend folder using the key `BASE_URL`. E.g. in local mode `BASE_URL=http://localhost:3000/`
 
 ## Install the dependencies
 ```bash

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -75,10 +75,6 @@ module.exports = function() {
             "^/api": ""
           }
         },
-        "/methods": {
-          target: "http://localhost:3000",
-          changeOrigin: true
-        }
       }
     },
 

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -74,6 +74,10 @@ module.exports = function() {
           pathRewrite: {
             "^/api": ""
           }
+        },
+        "/methods": {
+          target: "http://localhost:3000",
+          changeOrigin: true
         }
       }
     },

--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -21,21 +21,21 @@ export default ({ router }) => {
 
       if (
         config.url.indexOf("/users/login") > -1 ||
-        config.url.indexOf("/methods/sendResetEmail") > -1
+        config.url.indexOf("/api/methods/sendResetEmail") > -1
       ) {
         return config;
       }
 
       const allowedApiCalls = [
-        "/methods/getResidentDetailsApi",
-        "/methods/isResidentManagedByCurrentUserApi",
-        "/methods/isResidentManagedByCurrentUserApi",
-        "/methods/updateResidentInfo",
-        "/methods/getFeelingsPercentagesByResidentIdApi",
-        "/methods/getResidentAggregatedActivitiesApi",
-        "/methods/getCountsByTypeApi",
-        "/methods/getResidentActvitiesWithActivityAndFaciltatorNameApi",
-        "/methods/getDaywiseActivityDurationApi"
+        "/api/methods/getResidentDetailsApi",
+        "/api/methods/isResidentManagedByCurrentUserApi",
+        "/api/methods/isResidentManagedByCurrentUserApi",
+        "/api/methods/updateResidentInfo",
+        "/api/methods/getFeelingsPercentagesByResidentIdApi",
+        "/api/methods/getResidentAggregatedActivitiesApi",
+        "/api/methods/getCountsByTypeApi",
+        "/api/methods/getResidentActvitiesWithActivityAndFaciltatorNameApi",
+        "/api/methods/getDaywiseActivityDurationApi"
       ];
 
       if (new RegExp(allowedApiCalls.join("|")).test(config.url)) {

--- a/src/boot/axios.js
+++ b/src/boot/axios.js
@@ -5,7 +5,7 @@ import { checkIfLoggedIn } from "src/services/login.js";
 
 const axiosInstance = axios.create();
 
-export default () => {
+export default ({ router }) => {
   axiosInstance.interceptors.request.use(
     async config => {
       if (config.url.indexOf("/users/login") === -1) {
@@ -38,14 +38,13 @@ export default () => {
         "/methods/getDaywiseActivityDurationApi"
       ];
 
-      if (allowedApiCalls.indexOf(config.url) > -1) {
+      if (new RegExp(allowedApiCalls.join("|")).test(config.url)) {
         return config;
       }
 
       const result = await checkIfLoggedIn();
       if (!result) {
-        window.location.reload();
-        window.location.href = "/#/login";
+        router.push({ path: "/login" });
       }
       return config;
     },

--- a/src/components/ChangePassword.vue
+++ b/src/components/ChangePassword.vue
@@ -88,7 +88,7 @@ export default {
         })
       ) {
         this.closeDialog();
-        window.location.reload();
+        this.$router.go();
       }
     },
     closeDialog() {

--- a/src/components/GeriLifeTopbar.vue
+++ b/src/components/GeriLifeTopbar.vue
@@ -145,9 +145,9 @@ export default {
   methods: {
     async logoutAndRedirect() {
       if (await logout()) {
-        window.location.reload();
+        this.$router.go();
         if (!this.$route.path.startsWith("/resident/")) {
-          window.location.href = "/#/login";
+          this.$router.push({ path: "/login" });
         }
       }
     },

--- a/src/components/SettingsTopbar.vue
+++ b/src/components/SettingsTopbar.vue
@@ -71,9 +71,9 @@ export default {
     getCookie,
     async logoutAndRedirect() {
       if (await logout()) {
-        window.location.reload();
+        this.$router.go();
         if (!this.$route.path.startsWith("/resident/")) {
-          window.location.href = "/#/login";
+          this.$router.push({ path: "/login" });
         }
       }
     },

--- a/src/features/ResidentDetails/services/resident-services.js
+++ b/src/features/ResidentDetails/services/resident-services.js
@@ -5,7 +5,7 @@ import { i18n } from "src/boot/i18n";
 export const isResidentManagedByCurrentUserApi = async residentId => {
   try {
     const { data } = await $axios.post(
-      "/methods/isResidentManagedByCurrentUserApi",
+      "/api/methods/isResidentManagedByCurrentUserApi",
       {
         residentId
       }
@@ -23,7 +23,7 @@ export const updateResidentInfo = async document => {
     const modifier = { $set: { ...document } };
     delete modifier.$set._id;
 
-    await $axios.post("/methods/updateResidentInfo", {
+    await $axios.post("/api/methods/updateResidentInfo", {
       _id,
       modifier
     });
@@ -38,7 +38,7 @@ export const updateResidentInfo = async document => {
 export const getFeelingsPercentagesByResidentIdApi = async residentId => {
   try {
     const { data } = await $axios.post(
-      "/methods/getFeelingsPercentagesByResidentIdApi",
+      "/api/methods/getFeelingsPercentagesByResidentIdApi",
       {
         residentId
       }
@@ -75,7 +75,7 @@ export const getResidentAggregatedActivitiesApi = async (
 ) => {
   try {
     const { data } = await $axios.post(
-      "/methods/getResidentAggregatedActivitiesApi",
+      "/api/methods/getResidentAggregatedActivitiesApi",
       {
         residentId,
         timePeriod
@@ -90,7 +90,7 @@ export const getResidentAggregatedActivitiesApi = async (
 
 export const getCountsByTypeApi = async (residentId, type) => {
   try {
-    const { data } = await $axios.post("/methods/getCountsByTypeApi", {
+    const { data } = await $axios.post("/api/methods/getCountsByTypeApi", {
       residentId,
       type
     });
@@ -104,7 +104,7 @@ export const getCountsByTypeApi = async (residentId, type) => {
 export const getResidentActvitiesWithActivityAndFaciltatorNameApi = async residentId => {
   try {
     const { data } = await $axios.post(
-      "/methods/getResidentActvitiesWithActivityAndFaciltatorNameApi",
+      "/api/methods/getResidentActvitiesWithActivityAndFaciltatorNameApi",
       {
         residentId
       }
@@ -127,7 +127,7 @@ export const getResidentActvitiesWithActivityAndFaciltatorNameApi = async reside
 export const getDaywiseActivityDurationApi = async residentId => {
   try {
     const { data } = await $axios.post(
-      "/methods/getDaywiseActivityDurationApi",
+      "/api/methods/getDaywiseActivityDurationApi",
       {
         residentId
       }

--- a/src/features/activities/services/activities-services.js
+++ b/src/features/activities/services/activities-services.js
@@ -12,7 +12,7 @@ export const getActivities = async ({
 }) => {
   try {
     const { data } = await $axios.post(
-      "/methods/allUserVisibleActivities-paginated",
+      "/api/methods/allUserVisibleActivities-paginated",
       {
         currentPage,
         rowsPerPage,
@@ -31,7 +31,7 @@ export const getActivities = async ({
 
 export const deleteActivity = async id => {
   try {
-    await $axios.post("/methods/removeActivity", {
+    await $axios.post("/api/methods/removeActivity", {
       id
     });
     successNotifier(i18n.t("activityForm-delete-success"));

--- a/src/features/activity-types-setting/services/index.js
+++ b/src/features/activity-types-setting/services/index.js
@@ -4,7 +4,7 @@ import { i18n } from "src/boot/i18n";
 
 export const getAllActivityTypeIdsApi = async () => {
   try {
-    const response = await $axios.post("/methods/getAllActivityTypeIdsApi");
+    const response = await $axios.post("/api/methods/getAllActivityTypeIdsApi");
     return response.data;
   } catch (error) {
     errorNotifier(error);
@@ -14,7 +14,7 @@ export const getAllActivityTypeIdsApi = async () => {
 
 export const addActivityType = async formData => {
   try {
-    await $axios.post("/methods/addActivityType", formData);
+    await $axios.post("/api/methods/addActivityType", formData);
     successNotifier(i18n.t("activityType-create-successful"));
     return true;
   } catch (e) {
@@ -25,7 +25,7 @@ export const addActivityType = async formData => {
 
 export const removeActivityType = async formData => {
   try {
-    await $axios.post("/methods/removeActivityTypeApi", formData);
+    await $axios.post("/api/methods/removeActivityTypeApi", formData);
     successNotifier(i18n.t("activityType-delete-successful"));
     return true;
   } catch (e) {

--- a/src/features/data-settings/services/index.js
+++ b/src/features/data-settings/services/index.js
@@ -27,7 +27,7 @@ const exportXls = data => {
 
 export const exportData = async type => {
   try {
-    const response = await $axios.post("/methods/exportAllData");
+    const response = await $axios.post("/api/methods/exportAllData");
 
     if (type === "JSON") {
       exportJson(response.data);
@@ -43,7 +43,7 @@ export const exportData = async type => {
 
 export const JSONFileImport = async data => {
   try {
-    const response = await $axios.post("/methods/JSONFileImportApi", {
+    const response = await $axios.post("/api/methods/JSONFileImportApi", {
       fileData: data
     });
 

--- a/src/features/date-time-settings/services/index.js
+++ b/src/features/date-time-settings/services/index.js
@@ -4,7 +4,7 @@ import { i18n } from "src/boot/i18n";
 
 export const getTimezone = async () => {
   try {
-    const response = await $axios.post("/methods/getTimezone");
+    const response = await $axios.post("/api/methods/getTimezone");
     return response.data.value;
   } catch (error) {
     errorNotifier(error);
@@ -14,7 +14,7 @@ export const getTimezone = async () => {
 
 export const saveTimeZone = async tz => {
   try {
-    await $axios.post("/methods/createOrEditTimezoneSettingsApi", { selectedTimezone: tz });
+    await $axios.post("/api/methods/createOrEditTimezoneSettingsApi", { selectedTimezone: tz });
     successNotifier(i18n.t("tz-create-successful"));
     return true;
   } catch (e) {

--- a/src/features/event-log-settings/services/index.js
+++ b/src/features/event-log-settings/services/index.js
@@ -3,7 +3,7 @@ import { errorNotifier } from "src/utils/notifier.js";
 
 export const getUserEventLogs = async () => {
   try {
-    const response = await $axios.post("/methods/getUserEventLogs");
+    const response = await $axios.post("/api/methods/getUserEventLogs");
     return response.data;
   } catch (error) {
     errorNotifier(error);

--- a/src/features/home-details/services/detail-services.js
+++ b/src/features/home-details/services/detail-services.js
@@ -4,7 +4,7 @@ import { errorNotifier } from "src/utils/notifier.js";
 export const getHomeCurrentAndActiveResidents = async homeId => {
   try {
     const response = await $axios.post(
-      "/methods/getHomeCurrentAndActiveResidentsApi",
+      "/api/methods/getHomeCurrentAndActiveResidentsApi",
       {
         homeId
       }
@@ -19,7 +19,7 @@ export const getHomeCurrentAndActiveResidents = async homeId => {
 export const getSelectedResidentsRecentActiveDaysAndCount = async residentIds => {
   try {
     const response = await $axios.post(
-      "/methods/getSelectedResidentsRecentActiveDaysAndCount",
+      "/api/methods/getSelectedResidentsRecentActiveDaysAndCount",
       {
         residentIds
       }
@@ -34,7 +34,7 @@ export const getSelectedResidentsRecentActiveDaysAndCount = async residentIds =>
 export const getHomeActivityCountTrendApi = async homeId => {
   try {
     const response = await $axios.post(
-      "/methods/getHomeActivityCountTrendApi",
+      "/api/methods/getHomeActivityCountTrendApi",
       {
         homeId
       }
@@ -49,7 +49,7 @@ export const getHomeActivityCountTrendApi = async homeId => {
 export const getHomeResidentsActivitySumsByType = async (homeId, period) => {
   try {
     const response = await $axios.post(
-      "/methods/getHomeResidentsActivitySumsByType",
+      "/api/methods/getHomeResidentsActivitySumsByType",
       {
         homeId,
         period
@@ -64,7 +64,7 @@ export const getHomeResidentsActivitySumsByType = async (homeId, period) => {
 
 export const getHomeActivityTypeMetrics = async (homeId, period) => {
   try {
-    const response = await $axios.post("/methods/getHomeActivityTypeMetrics", {
+    const response = await $axios.post("/api/methods/getHomeActivityTypeMetrics", {
       homeId,
       period
     });
@@ -81,7 +81,7 @@ export const getHomeActivitiesFacilitatorRoleMetrics = async (
 ) => {
   try {
     const response = await $axios.post(
-      "/methods/getHomeActivitiesFacilitatorRoleMetrics",
+      "/api/methods/getHomeActivitiesFacilitatorRoleMetrics",
       {
         homeId,
         period
@@ -96,7 +96,7 @@ export const getHomeActivitiesFacilitatorRoleMetrics = async (
 
 export const getHomeActivities = async homeId => {
   try {
-    const response = await $axios.post("/methods/getHomeActivitiesApi", {
+    const response = await $axios.post("/api/methods/getHomeActivitiesApi", {
       homeId
     });
     return response.data;

--- a/src/features/homes-report/services/list-services.js
+++ b/src/features/homes-report/services/list-services.js
@@ -7,7 +7,7 @@ export const getMonthlyAggregatedHomeResidentActivities = async (
 ) => {
   try {
     const response = await $axios.post(
-      "/methods/getMonthlyAggregatedHomeResidentActivitiesApi",
+      "/api/methods/getMonthlyAggregatedHomeResidentActivitiesApi",
       {
         homeId,
         timePeriod

--- a/src/features/homes/services/group-manager.js
+++ b/src/features/homes/services/group-manager.js
@@ -4,7 +4,7 @@ import { i18n } from "src/boot/i18n";
 
 export const getCurrentManagers = async groupId => {
   try {
-    const response = await $axios.post("/methods/getCurrentManagersApi", {
+    const response = await $axios.post("/api/methods/getCurrentManagersApi", {
       groupId
     });
     return response.data;
@@ -16,7 +16,7 @@ export const getCurrentManagers = async groupId => {
 
 export const getEligibleManagers = async currentManagers => {
   try {
-    const response = await $axios.post("/methods/getEligibleManagerListApi", {
+    const response = await $axios.post("/api/methods/getEligibleManagerListApi", {
       idsToFilter: currentManagers
     });
     return response.data;
@@ -28,7 +28,7 @@ export const getEligibleManagers = async currentManagers => {
 
 export const assignManager = async ({ groupId, users }) => {
   try {
-    await $axios.post("/methods/assignManager", {
+    await $axios.post("/api/methods/assignManager", {
       groupId,
       users
     });
@@ -43,7 +43,7 @@ export const assignManager = async ({ groupId, users }) => {
 export const revokeManagerPermission = async (groupId, userId) => {
   try {
     const { data: resp } = await $axios.post(
-      "/methods/revokeManagerPermission",
+      "/api/methods/revokeManagerPermission",
       {
         groupId,
         userId

--- a/src/features/homes/services/homes-list.js
+++ b/src/features/homes/services/homes-list.js
@@ -4,7 +4,7 @@ import { i18n } from "src/boot/i18n";
 
 export const getUserGroups = async () => {
   try {
-    const { data } = await $axios.post("/methods/currentUserGroups");
+    const { data } = await $axios.post("/api/methods/currentUserGroups");
     return data;
   } catch (error) {
     errorNotifier(error);
@@ -14,7 +14,7 @@ export const getUserGroups = async () => {
 
 export const getHomesWithActivityLevel = async groupId => {
   try {
-    const { data } = await $axios.post("/methods/getHomesWithActivityLevel", {
+    const { data } = await $axios.post("/api/methods/getHomesWithActivityLevel", {
       groupId
     });
     return data;
@@ -31,7 +31,7 @@ export const addOrUpdateAGroup = async groupDetails => {
       payload = { _id: groupDetails._id, modifier: { $set: groupDetails } };
       delete payload.modifier._id;
     }
-    await $axios.post("/methods/addOrUpdateAGroup", payload);
+    await $axios.post("/api/methods/addOrUpdateAGroup", payload);
 
     successNotifier(
       i18n.t(`groupModal-${groupDetails._id ? "update" : "create"}-successful`)
@@ -51,7 +51,7 @@ export const addOrUpdateHome = async homeDetails => {
       delete payload.modifier.$set._id;
       delete payload.modifier.$set.groupId;
     }
-    await $axios.post("/methods/addOrUpdateHome", payload);
+    await $axios.post("/api/methods/addOrUpdateHome", payload);
 
     successNotifier(
       i18n.t(`homeModal-${homeDetails._id ? "update" : "create"}-successful`)

--- a/src/features/login/index.vue
+++ b/src/features/login/index.vue
@@ -47,7 +47,6 @@
       <q-card-section class="row">
         <q-space />
         <q-form class="col-8" ref="forgotPwdForm">
-
           <q-input
             v-model="toEmail"
             :rules="[(v) => requiredValidation(v), (v) => validateEmail(v)]"
@@ -94,7 +93,6 @@ export default {
   },
   methods: {
     async login() {
-      console.log("login form submitted")
       const result = await this.$refs.loginForm.validate();
 
       if (!result) {
@@ -112,8 +110,8 @@ export default {
         await this.$store.dispatch("user/getUserDetails");
         await this.$store.dispatch("user/getGroupsOfCurrentUser");
 
-        window.location.reload();
-        window.location.href = "/#/";
+        this.$router.push({ path: "/" });
+        this.$router.go();
       } else {
         console.log("Could not log in to server.");
       }

--- a/src/features/reports/services/chart-services.js
+++ b/src/features/reports/services/chart-services.js
@@ -51,7 +51,7 @@ export const prepareChartData = (
 export const getActivitiesAggregateReport = async (timePeriod, aggregateBy) => {
   try {
     const response = await $axios.post(
-      "/methods/getActivitiesAggregateReportApi",
+      "/api/methods/getActivitiesAggregateReportApi",
       {
         timePeriod,
         aggregateBy

--- a/src/features/residents/services/residency-services.js
+++ b/src/features/residents/services/residency-services.js
@@ -5,7 +5,7 @@ import { i18n } from "src/boot/i18n";
 export const getResidentsWithHomeAndResidentDetailsApi = async includeDeparted => {
   try {
     const { data } = await $axios.post(
-      "/methods/getResidentsWithHomeAndResidentDetailsApi",
+      "/api/methods/getResidentsWithHomeAndResidentDetailsApi",
       {
         includeDeparted
       }
@@ -19,7 +19,7 @@ export const getResidentsWithHomeAndResidentDetailsApi = async includeDeparted =
 
 export const addNewResidentAndResidency = async document => {
   try {
-    await $axios.post("/methods/addNewResidentAndResidencyApi", {
+    await $axios.post("/api/methods/addNewResidentAndResidencyApi", {
       document
     });
     successNotifier(i18n.t("residency-create-successful"));
@@ -32,7 +32,7 @@ export const addNewResidentAndResidency = async document => {
 
 export const addNewResidencyWithExistingResident = async document => {
   try {
-    await $axios.post("/methods/addNewResidencyWithExistingResident", document);
+    await $axios.post("/api/methods/addNewResidencyWithExistingResident", document);
     successNotifier(i18n.t("residency-create-successful"));
     return true;
   } catch (error) {
@@ -43,7 +43,7 @@ export const addNewResidencyWithExistingResident = async document => {
 
 export const editResidency = async document => {
   try {
-    await $axios.post("/methods/editResidency", document);
+    await $axios.post("/api/methods/editResidency", document);
     successNotifier(i18n.t("residency-update-successful"));
     return true;
   } catch (error) {

--- a/src/features/roles-settings/services/index.js
+++ b/src/features/roles-settings/services/index.js
@@ -4,7 +4,7 @@ import { i18n } from "src/boot/i18n";
 
 export const getRolesExceptAdmin = async () => {
   try {
-    const response = await $axios.post("/methods/getRolesExceptAdmin");
+    const response = await $axios.post("/api/methods/getRolesExceptAdmin");
     return response.data;
   } catch (error) {
     errorNotifier(error);
@@ -14,7 +14,7 @@ export const getRolesExceptAdmin = async () => {
 
 export const addRole = async formData => {
   try {
-    await $axios.post("/methods/addRole", formData);
+    await $axios.post("/api/methods/addRole", formData);
     successNotifier(i18n.t("roles-create-successful"));
     return true;
   } catch (e) {

--- a/src/features/user-settings/services/index.js
+++ b/src/features/user-settings/services/index.js
@@ -4,7 +4,7 @@ import { i18n } from "src/boot/i18n";
 
 export const getUserList = async () => {
   try {
-    const { data } = await $axios.post("/methods/getUserListApi");
+    const { data } = await $axios.post("/api/methods/getUserListApi");
     return data.map(r => ({
       ...r,
       Email: r.emails[0].address,
@@ -18,7 +18,7 @@ export const getUserList = async () => {
 
 export const getSingleUserGroupIdsApi = async (userId, allGroups = []) => {
   try {
-    const { data } = await $axios.post("/methods/getSingleUserGroupIdsApi", {
+    const { data } = await $axios.post("/api/methods/getSingleUserGroupIdsApi", {
       userId
     });
     return data;
@@ -30,7 +30,7 @@ export const getSingleUserGroupIdsApi = async (userId, allGroups = []) => {
 
 export const addSingleUserPermissionsApi = async (userId, groupIds) => {
   try {
-    await $axios.post("/methods/addSingleUserPermissionsApi", {
+    await $axios.post("/api/methods/addSingleUserPermissionsApi", {
       userId,
       groupIds
     });
@@ -45,7 +45,7 @@ export const addSingleUserPermissionsApi = async (userId, groupIds) => {
 
 export const deleteUser = async user => {
   try {
-    await $axios.post("/methods/deleteUser", user);
+    await $axios.post("/api/methods/deleteUser", user);
     successNotifier(i18n.t("user-remove-successful"));
 
     return true;
@@ -57,7 +57,7 @@ export const deleteUser = async user => {
 
 export const editUserFormSubmit = async user => {
   try {
-    await $axios.post("/methods/editUserFormSubmit", user);
+    await $axios.post("/api/methods/editUserFormSubmit", user);
 
     return user._id;
   } catch (error) {
@@ -68,7 +68,7 @@ export const editUserFormSubmit = async user => {
 
 export const addUser = async user => {
   try {
-    const { data } = await $axios.post("/methods/addUser", user);
+    const { data } = await $axios.post("/api/methods/addUser", user);
 
     return data;
   } catch (error) {
@@ -80,7 +80,7 @@ export const addUser = async user => {
 export const updateAdministratorRights = async (user, userId) => {
   try {
     await $axios.post(
-      `/methods/${
+      `/api/methods/${
         user.isAdmin ? "addUserToAdminRoleApi" : "removeUserFromAdminRoleApi"
       }`,
       { userId }
@@ -94,7 +94,7 @@ export const updateAdministratorRights = async (user, userId) => {
 
 export const addUsersAndSendEnrollmentEmails = async doc => {
   try {
-    await $axios.post("/methods/addUsersAndSendEnrollmentEmails", doc);
+    await $axios.post("/api/methods/addUsersAndSendEnrollmentEmails", doc);
     successNotifier(i18n.t("enroll-user-successful"));
 
     return true;

--- a/src/store/user/actions.js
+++ b/src/store/user/actions.js
@@ -3,7 +3,7 @@ import { $axios } from "src/boot/axios";
 
 export async function getUserDetails({ commit }) {
   try {
-    const { data } = await $axios.post("/methods/getUserDetails");
+    const { data } = await $axios.post("/api/methods/getUserDetails");
     commit("setUserDetails", data);
   } catch (error) {
     errorNotifier(error);
@@ -12,7 +12,7 @@ export async function getUserDetails({ commit }) {
 
 export async function getGroupsOfCurrentUser({ commit }) {
   try {
-    const { data } = await $axios.post("/methods/getHomesOfCurrentUser");
+    const { data } = await $axios.post("/api/methods/getHomesOfCurrentUser");
     commit("setUserManagedHomes", data);
   } catch (error) {
     errorNotifier(error);


### PR DESCRIPTION
closes #35 
closes #40 

1. Adding local proxy for APIs starting with methods to make proxy work in dev local env.
2. Using router push and reload for login navigations. Page reload is required at some places to update DOM correctly hence using `this.$outer.go()`.